### PR TITLE
Added parameter '-s' to specify the server address

### DIFF
--- a/ntpstat
+++ b/ntpstat
@@ -91,7 +91,7 @@ get_ntpd_state() {
     local output syspeer_id disp delay
     local leap source address stratum distance poll
 
-    output=$("${NTPQ[@]}" -c "rv 0" 2> /dev/null) || return 2
+    output=$("${NTPQ[@]}" -c "rv 0" ${ntp_server_address} 2> /dev/null) || return 2
     [[ $output == *"associd"*"status"* ]] || return 3
 
     leap=$(parse_rv_field "$output" "leap")
@@ -117,7 +117,7 @@ get_ntpd_state() {
     distance=$(echo "$delay $disp" | awk '{ printf "%.3f", $1 / 2.0 + $2 }')
 
     syspeer_id=$(parse_rv_field "$output" "peer")
-    output=$("${NTPQ[@]}" -c "rv $syspeer_id" 2> /dev/null) || return 5
+    output=$("${NTPQ[@]}" -c "rv $syspeer_id" ${ntp_server_address} 2> /dev/null) || return 5
 
     if [ "$source" = "NTP server" ]; then
         address=$(parse_rv_field "$output" "srcadr")
@@ -129,13 +129,18 @@ get_ntpd_state() {
 
 
 max_distance=""
-while getopts "m:h" opt; do
+ntp_server_address=""
+while getopts "m:s:h" opt; do
     case $opt in
         m)
             max_distance=$OPTARG
             ;;
+        s)
+            ntp_server_address=$OPTARG
+            CHRONYC+=("-h" "${OPTARG}" )
+            ;;
         *)
-            echo "Usage: $0 [-m MAXERROR]"
+            echo "Usage: $0 [-m MAXERROR] [-s SERVER_ADDRES]"
             [ "$opt" = "h" ] && exit 0 || exit 3
             ;;
     esac

--- a/ntpstat
+++ b/ntpstat
@@ -91,7 +91,7 @@ get_ntpd_state() {
     local output syspeer_id disp delay
     local leap source address stratum distance poll
 
-    output=$("${NTPQ[@]}" -c "rv 0" ${ntp_server_address} 2> /dev/null) || return 2
+    output=$("${NTPQ[@]}" -c "rv 0" 2> /dev/null) || return 2
     [[ $output == *"associd"*"status"* ]] || return 3
 
     leap=$(parse_rv_field "$output" "leap")
@@ -117,7 +117,7 @@ get_ntpd_state() {
     distance=$(echo "$delay $disp" | awk '{ printf "%.3f", $1 / 2.0 + $2 }')
 
     syspeer_id=$(parse_rv_field "$output" "peer")
-    output=$("${NTPQ[@]}" -c "rv $syspeer_id" ${ntp_server_address} 2> /dev/null) || return 5
+    output=$("${NTPQ[@]}" -c "rv $syspeer_id" 2> /dev/null) || return 5
 
     if [ "$source" = "NTP server" ]; then
         address=$(parse_rv_field "$output" "srcadr")
@@ -129,18 +129,13 @@ get_ntpd_state() {
 
 
 max_distance=""
-ntp_server_address=""
-while getopts "m:s:h" opt; do
+while getopts "m:h" opt; do
     case $opt in
         m)
             max_distance=$OPTARG
             ;;
-        s)
-            ntp_server_address=$OPTARG
-            CHRONYC+=("-h" "${OPTARG}" )
-            ;;
         *)
-            echo "Usage: $0 [-m MAXERROR] [-s SERVER_ADDRES]"
+            echo "Usage: $0 [-m MAXERROR]"
             [ "$opt" = "h" ] && exit 0 || exit 3
             ;;
     esac

--- a/ntpstat
+++ b/ntpstat
@@ -129,13 +129,21 @@ get_ntpd_state() {
 
 
 max_distance=""
-while getopts "m:h" opt; do
+while getopts "m:h46" opt; do
     case $opt in
         m)
             max_distance=$OPTARG
             ;;
+        4)
+            CHRONYC+=("-4")
+            NTPQ+=("-4")
+            ;;
+        6)
+            CHRONYC+=("-6")
+            NTPQ+=("-6")
+            ;;
         *)
-            echo "Usage: $0 [-m MAXERROR]"
+            echo "Usage: $0 [-m MAXERROR] [-4|-6]"
             [ "$opt" = "h" ] && exit 0 || exit 3
             ;;
     esac

--- a/ntpstat.1
+++ b/ntpstat.1
@@ -3,7 +3,7 @@
 ntpstat \- Print NTP synchronisation status
 
 .SH SYNOPSIS
-\fBntpstat\fR [\fB-m\fR \fIMAXERROR\fR]
+\fBntpstat\fR [\fB-m\fR \fIMAXERROR\fR] [\fB-4\fR|\fB-6\fR]
 
 .SH DESCRIPTION
 \fBntpstat\fR is a script which prints a brief summary of the system clock's
@@ -29,6 +29,12 @@ specified.
 Specify a maximum acceptable error of the clock in milliseconds. If the
 clock is synchronised, but its maximum estimated error is larger than
 \fIMAXERROR\fR, or is unknown, \fBntpstat\fR will exit with a status of 1.
+.TP 8
+\fB-4\fR
+Force use ipv4 to connect (127.0.0.1)
+.TP 8
+\fB-6\fR
+Force use ipv6 to connect (::1)
 .TP 8
 \fB-h\fR
 Print a help message and exit.

--- a/ntpstat.1
+++ b/ntpstat.1
@@ -3,7 +3,7 @@
 ntpstat \- Print NTP synchronisation status
 
 .SH SYNOPSIS
-\fBntpstat\fR [\fB-m\fR \fIMAXERROR\fR] [\fB-s\fR \fINTP_SERVER_ADDRESS\fR]
+\fBntpstat\fR [\fB-m\fR \fIMAXERROR\fR]
 
 .SH DESCRIPTION
 \fBntpstat\fR is a script which prints a brief summary of the system clock's
@@ -29,10 +29,6 @@ specified.
 Specify a maximum acceptable error of the clock in milliseconds. If the
 clock is synchronised, but its maximum estimated error is larger than
 \fIMAXERROR\fR, or is unknown, \fBntpstat\fR will exit with a status of 1.
-.TP 8
-\fB-s\fR \fINTP_SERVER_ADDRESS\fR
-Specify a address of the NTP-server to connect \fBntpstat\fR. This can be
-an ipv4, ipv6 or socket (socket can only be used with chronyd).
 .TP 8
 \fB-h\fR
 Print a help message and exit.

--- a/ntpstat.1
+++ b/ntpstat.1
@@ -3,7 +3,7 @@
 ntpstat \- Print NTP synchronisation status
 
 .SH SYNOPSIS
-\fBntpstat\fR [\fB-m\fR \fIMAXERROR\fR]
+\fBntpstat\fR [\fB-m\fR \fIMAXERROR\fR] [\fB-s\fR \fINTP_SERVER_ADDRESS\fR]
 
 .SH DESCRIPTION
 \fBntpstat\fR is a script which prints a brief summary of the system clock's
@@ -29,6 +29,10 @@ specified.
 Specify a maximum acceptable error of the clock in milliseconds. If the
 clock is synchronised, but its maximum estimated error is larger than
 \fIMAXERROR\fR, or is unknown, \fBntpstat\fR will exit with a status of 1.
+.TP 8
+\fB-s\fR \fINTP_SERVER_ADDRESS\fR
+Specify a address of the NTP-server to connect \fBntpstat\fR. This can be
+an ipv4, ipv6 or socket (socket can only be used with chronyd).
 .TP 8
 \fB-h\fR
 Print a help message and exit.


### PR DESCRIPTION
I run ntpd on ipv4 only, and ntpstat tries to connect via ipv6-address ::1. I added the '-s' parameter to tell ntpstat to connect to 127.0.0.1. Also, in this parameter you can specify the path to the socket for chronyd.