### PR TITLE
Invoke bash with /usr/bin/env for more Posix compatibility

### DIFF
--- a/ntpstat
+++ b/ntpstat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is a shell script which prints the ntpd or chronyd synchronisation
 # status, using the ntpq or chronyc program. It emulates the original


### PR DESCRIPTION
There is no guarantee that bash is actually installed in /bin.